### PR TITLE
HotFix: 카카오톡 전송 과정의 오류 해결

### DIFF
--- a/src/main/java/com/example/fingerprint_backend/scheduled/KakaoScheduled.java
+++ b/src/main/java/com/example/fingerprint_backend/scheduled/KakaoScheduled.java
@@ -91,7 +91,7 @@ public class KakaoScheduled {
         for (String stdNum : members) {
             Optional<KakaoEntity> targetStudentKakao = kakaoRepository.findById(stdNum);
 
-            if (targetStudentKakao.isEmpty()) {
+            if (targetStudentKakao.isEmpty() || targetStudentKakao.get().getUuid() == null || targetStudentKakao.get().getUuid().isEmpty()) {
                 continue;
             }
 


### PR DESCRIPTION
- 카카오톡 전송 과정에서 만약 uuid가 비어있는 사람이 있을 경우 오류가 발생하는 버그 해결